### PR TITLE
Correct XML file name

### DIFF
--- a/t/WWW/SFDC/Zip.t
+++ b/t/WWW/SFDC/Zip.t
@@ -63,7 +63,7 @@ subtest "zip and unzip is eidempotent", sub {
   ok -e "$FOLDER/workflows/Site.workflow";
   is (read_file("$FOLDER/workflows/Site.workflow"), $WORKFLOW);
   ok -e "$FOLDER/package.xml";
-  is (read_file("$FOLDER/Package.xml"), $PACKAGE);
+  is (read_file("$FOLDER/package.xml"), $PACKAGE);
   done_testing();
 };
 
@@ -81,7 +81,7 @@ subtest "can skip file using callback", sub {
   ok -e "$FOLDER/workflows/Site.workflow"
     and is (read_file("$FOLDER/workflows/Site.workflow"), $WORKFLOW);
   ok -e "$FOLDER/package.xml"
-    and is (read_file("$FOLDER/Package.xml"), $PACKAGE);
+    and is (read_file("$FOLDER/package.xml"), $PACKAGE);
   done_testing();
 };
 
@@ -106,7 +106,7 @@ subtest "can modify file using callback", sub {
   ok -e "$FOLDER/workflows/Site.workflow"
     and is read_file("$FOLDER/workflows/Site.workflow"), $WORKFLOW;
   ok -e "$FOLDER/package.xml"
-    and is read_file("$FOLDER/Package.xml"), $PACKAGE;
+    and is read_file("$FOLDER/package.xml"), $PACKAGE;
   done_testing();
 };
 


### PR DESCRIPTION
`t/WWW/SFDC/Zip.t` is failed on case sensitive file system.

```
prove -bv t/WWW/SFDC/Zip.t
t/WWW/SFDC/Zip.t .. 
ok 1 - use WWW::SFDC::Zip;
    # Subtest: unzip pre-defined zip file
    ok 1
    ok 2
    ok 3
    ok 4
    ok 5
    ok 6
    1..6
ok 2 - unzip pre-defined zip file
    # Subtest: zip and unzip is eidempotent
    ok 1
    ok 2
    ok 3
    ok 4
    ok 5
read_file 'temp_test/Package.xml' - sysopen: No such file or directory at t/WWW/SFDC/Zip.t line 66.
    # Child (zip and unzip is eidempotent) exited without calling finalize()
not ok 3 - zip and unzip is eidempotent

#   Failed test 'zip and unzip is eidempotent'
#   at /home/syohei/.plenv/versions/5.22.0/lib/perl5/5.22.0/Test/Builder.pm line 279.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 2 just after 3.
Dubious, test returned 2 (wstat 512, 0x200)
Failed 1/3 subtests 

Test Summary Report
-------------------
t/WWW/SFDC/Zip.t (Wstat: 512 Tests: 3 Failed: 1)
  Failed test:  3
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=3,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.06 cusr  0.00 csys =  0.08 CPU)
Result: FAIL
```
